### PR TITLE
Pancake menuの縦並びデザインの適用

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -238,6 +238,10 @@ body {
   flex-wrap: wrap;
 }
 
+.menu_tandem{
+  display: block;
+}
+
 .menu_list_recommended {
   /* トップページのメニューリストには別途paddingの設定（マルチクラス） */
   padding-bottom: 50px;
@@ -250,6 +254,11 @@ body {
   box-shadow: 2px 2px 5px rgba(0,0,0,0.4);
   margin-bottom: 20px;
 }
+
+.menu_max_width{
+  width: 100%;
+}
+
 .menu_item_content {
   width: 45%;
   padding: 10px;

--- a/menu.html
+++ b/menu.html
@@ -62,11 +62,11 @@
             お好みで上品な甘さのメープルシロップをかけてお召し上がりください。
           </p>
         </section>
-       
+        
         <section class="pancake_menu">
           <h1 class="section_title">Pancake menu</h1>
-          <ul class="menu_list">
-            <li class="menu_item">
+          <ul class="menu_list menu_tandem">
+            <li class="menu_item menu_max_width">
               <div class="menu_item_content">
                 <h2 class="menu_item_title">ブルーベリーパンケーキ</h2>
                 <p class="menu_item_price">¥1,200</p>
@@ -74,7 +74,7 @@
               </div>
               <img src="images/sample_pancake1.jpg" class="menu_item_image">
             </li>
-            <li class="menu_item">
+            <li class="menu_item menu_max_width">
               <div class="menu_item_content">
                 <h2 class="menu_item_title">ストロベリーパンケーキ</h2>
                 <p class="menu_item_price">¥1,300</p>
@@ -82,7 +82,7 @@
               </div>
               <img src="images/sample_pancake2.jpg" class="menu_item_image">
             </li>
-            <li class="menu_item">
+            <li class="menu_item menu_max_width">
               <div class="menu_item_content">
                 <h2 class="menu_item_title">ふわふわパンケーキ</h2>
                 <p class="menu_item_price">¥1,100</p>
@@ -90,7 +90,7 @@
               </div>
               <img src="images/sample_pancake3.jpg" class="menu_item_image">
             </li>
-            <li class="menu_item">
+            <li class="menu_item menu_max_width">
               <div class="menu_item_content">
                 <h2 class="menu_item_title">バナナパンケーキ</h2>
                 <p class="menu_item_price">¥1,200</p>


### PR DESCRIPTION
## menu.html内のデザインの変更
- Pancake menuを縦並びに変更しました
- 68行目にmenu_tandemクラスの追加
- 69行目, 77行目, 85行目, 93行目にmenu_max_widthクラスの追加

## main.css内に追記
- 241行目にmenu_tademにdisplay blockを追記し、menu_listのdisplay flexを打ち消し
- 258行目にmenu_max_widthにwidth 100%を追記し、menu_itemの横幅を上書き